### PR TITLE
modify the config

### DIFF
--- a/.github/workflows/test_renovate.yml
+++ b/.github/workflows/test_renovate.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.0
       - uses: yu-iskw/test-renovate@v1
         with:
           name: "Renovate"

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "allowedVersions": "/^(v)?[0-9]+\\.[0-9]+\\.[0-9]+$/",
       "pinDigests": true
     }
   ]


### PR DESCRIPTION
### **PR Type**
Configuration changes


___

### **Description**
- Updated GitHub Actions workflow to use a specific version.

- Removed `allowedVersions` rule from `renovate.json`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_renovate.yml</strong><dd><code>Update GitHub Actions workflow version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test_renovate.yml

- Updated `actions/checkout` to version `v3.5.0`.


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/test-renovate/pull/11/files#diff-c7ac7414c5f7184f08dd75f1ce1d96623a90c2ca6dc0612da36b263d8d1dc110">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Modify renovate configuration rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

- Removed `allowedVersions` rule for GitHub Actions manager.


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/test-renovate/pull/11/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>